### PR TITLE
add device to config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -92,3 +92,14 @@ func LoadConfig() (err error) {
 	err = viper.Unmarshal(&GlobalConfig)
 	return
 }
+
+func AddDevice(device Device) (err error) {
+	if GlobalConfig.Devices == nil {
+		GlobalConfig.Devices = make([]Device, 0)
+	}
+	GlobalConfig.Devices = append(GlobalConfig.Devices, device)
+	viper.Set("devices", GlobalConfig.Devices)
+	log.Println(GlobalConfig.Devices)
+	err = viper.WriteConfig()
+	return
+}


### PR DESCRIPTION
Add `AddDevice` func to the config package. This appends a new device to the configuration and writes to file.

Example usage:

```
config.AddDevice(config.Device{
  Id:   "test",
  Type: "test",
  // ...etc
  Config: config.DeviceConfig{
    Port: 1,
    // ...etc
  },
})
```